### PR TITLE
[FEAT] 액자 기본 이미지 추가 / 액자 이미지 깨짐 수정

### DIFF
--- a/KnockKnock/KnockKnock/Album/AlbumCollectionViewCell.swift
+++ b/KnockKnock/KnockKnock/Album/AlbumCollectionViewCell.swift
@@ -15,7 +15,8 @@ final class albumImageCell: UICollectionViewCell {
     let imageView: UIImageView = {
         let view = UIImageView()
         view.backgroundColor = .gray
-        view.contentMode = .scaleToFill
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()

--- a/KnockKnock/KnockKnock/Album/MainAlbumViewController.swift
+++ b/KnockKnock/KnockKnock/Album/MainAlbumViewController.swift
@@ -115,7 +115,10 @@ extension MainAlbumViewController: PHPickerViewControllerDelegate {
                 item.loadObject(ofClass: UIImage.self) { image, error in
                     DispatchQueue.main.async {
                         guard let image = image as? UIImage else { return }
-                        CoreDataManager.shared.saveAlbumCoreData(image: image.pngData()!)
+                        let orientedImage = image.fixedOrientation()
+                        if let imageData = orientedImage.pngData() {
+                            CoreDataManager.shared.saveAlbumCoreData(image: imageData)
+                        }
                         CoreDataManager.shared.readAlbumCoreData()
                         self.collectionView.reloadData()
                     }
@@ -160,5 +163,65 @@ extension MainAlbumViewController: UICollectionViewDelegate {
         cellDetailVC.getindex = indexPath.item
         cellDetailVC.getimage = UIImage(data: CoreDataManager.shared.albumImageArray!.reversed()[indexPath.item].value(forKey: "image") as! Data)
         self.navigationController?.pushViewController(cellDetailVC,animated: true)
+    }
+}
+
+//사진 방향 회전 시 원래대로 복구하는 함수
+extension UIImage {
+    func fixedOrientation() -> UIImage {
+
+        if imageOrientation == .up {
+            return self
+        }
+
+        var transform: CGAffineTransform = CGAffineTransform.identity
+
+        switch imageOrientation {
+        case .down, .downMirrored:
+            transform = transform.translatedBy(x: size.width, y: size.height)
+            transform = transform.rotated(by: CGFloat.pi)
+        case .left, .leftMirrored:
+            transform = transform.translatedBy(x: size.width, y: 0)
+            transform = transform.rotated(by: CGFloat.pi / 2)
+        case .right, .rightMirrored:
+            transform = transform.translatedBy(x: 0, y: size.height)
+            transform = transform.rotated(by: CGFloat.pi / -2)
+        case .up, .upMirrored:
+            break
+        default:
+            print("Image OK")
+        }
+
+        switch imageOrientation {
+        case .upMirrored, .downMirrored:
+            transform.translatedBy(x: size.width, y: 0)
+            transform.scaledBy(x: -1, y: 1)
+        case .leftMirrored, .rightMirrored:
+            transform.translatedBy(x: size.height, y: 0)
+            transform.scaledBy(x: -1, y: 1)
+        case .up, .down, .left, .right:
+            break
+        default:
+            print("Image OK")
+        }
+
+        if let cgImage = self.cgImage, let colorSpace = cgImage.colorSpace,
+            let ctx: CGContext = CGContext(data: nil, width: Int(size.width), height: Int(size.height), bitsPerComponent: cgImage.bitsPerComponent, bytesPerRow: 0, space: colorSpace, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue) {
+            ctx.concatenate(transform)
+
+            switch imageOrientation {
+            case .left, .leftMirrored, .right, .rightMirrored:
+                ctx.draw(cgImage, in: CGRect(x: 0, y: 0, width: size.height, height: size.width))
+            default:
+                ctx.draw(cgImage, in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
+            }
+            if let ctxImage: CGImage = ctx.makeImage() {
+                return UIImage(cgImage: ctxImage)
+            } else {
+                return self
+            }
+        } else {
+            return self
+        }
     }
 }

--- a/KnockKnock/KnockKnock/Frame/FrameCollectionViewCell.swift
+++ b/KnockKnock/KnockKnock/Frame/FrameCollectionViewCell.swift
@@ -14,7 +14,8 @@ class FrameCollectionViewCell: UICollectionViewCell {
     let imageView: UIImageView = {
         let view = UIImageView()
         view.backgroundColor = .gray
-        view.contentMode = .scaleToFill
+        view.contentMode = .scaleAspectFill
+        view.clipsToBounds = true
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()

--- a/KnockKnock/KnockKnock/Frame/FrameViewController.swift
+++ b/KnockKnock/KnockKnock/Frame/FrameViewController.swift
@@ -65,7 +65,7 @@ class FrameViewController: UIViewController {
             collectionView.topAnchor.constraint(equalTo: view.topAnchor, constant: 100),
             collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             
-            cancelButton.bottomAnchor.constraint(equalTo: collectionView.topAnchor, constant: -25),
+            cancelButton.bottomAnchor.constraint(equalTo: collectionView.topAnchor, constant: -15),
             cancelButton.leftAnchor.constraint(equalTo: collectionView.leftAnchor, constant: 15)
         ])
         collectionView.dataSource = self

--- a/KnockKnock/KnockKnock/Frame/MainFrameViewController.swift
+++ b/KnockKnock/KnockKnock/Frame/MainFrameViewController.swift
@@ -41,8 +41,7 @@ class MainFrameViewController: UIViewController {
         ])
         
         readImage()
-        
-        print("메인프레임 컨트롤러 뷰디드로드 2")
+    
         print("\(CoreDataManager.shared.frameImage?.count)")
     }
     
@@ -91,6 +90,7 @@ class MainFrameViewController: UIViewController {
         frameImageView.setNeedsDisplay()
     }
     
+    //CoreData의 이미지를 불러와서 표시하는 함수
     func readImage() {
         CoreDataManager.shared.readFrameCoreData()
         guard let image = CoreDataManager.shared.frameImage?.last else {return}

--- a/KnockKnock/KnockKnock/Frame/MainFrameViewController.swift
+++ b/KnockKnock/KnockKnock/Frame/MainFrameViewController.swift
@@ -44,7 +44,7 @@ class MainFrameViewController: UIViewController {
         //frameImageView AutoLayout
         NSLayoutConstraint.activate([
             self.frameImageView.widthAnchor.constraint(equalTo: view.widthAnchor),
-            self.frameImageView.heightAnchor.constraint(equalTo: view.heightAnchor),
+            self.frameImageView.heightAnchor.constraint(equalTo: view.widthAnchor, multiplier: 4/3),
             self.frameImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             self.frameImageView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
         ])

--- a/KnockKnock/KnockKnock/RoomViewController.swift
+++ b/KnockKnock/KnockKnock/RoomViewController.swift
@@ -54,7 +54,8 @@ class RoomViewController: UIViewController {
     //액자 사진 버튼 ImageView
     let frameHasImageView: UIImageView = {
         let imageView = UIImageView(frame: .zero)
-        imageView.contentMode = .scaleToFill
+        imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
         imageView.translatesAutoresizingMaskIntoConstraints = false
         CoreDataManager.shared.readFrameCoreData()
         if let image = CoreDataManager.shared.frameImage?.last, let frameImageData = image.value(forKey: "image") as? Data {

--- a/KnockKnock/KnockKnock/RoomViewController.swift
+++ b/KnockKnock/KnockKnock/RoomViewController.swift
@@ -180,8 +180,6 @@ class RoomViewController: UIViewController {
         if let image = CoreDataManager.shared.frameImage?.last {
             if let frameImageData = image.value(forKey: "image") as? Data {
                 frameHasImageView.image = UIImage(data: frameImageData)
-                //테스트
-                print("해겨ㅑㄹ")
             }
         }
     }

--- a/KnockKnock/KnockKnock/RoomViewController.swift
+++ b/KnockKnock/KnockKnock/RoomViewController.swift
@@ -9,12 +9,12 @@ import UIKit
 
 class RoomViewController: UIViewController {
     
-    //DoorViewController 실행 되었는지 확인
+    // DoorViewController 실행 되었는지 확인
     var isDoorView: Bool = true
     let doorViewController = DoorViewController()
     let keychainManager = KeychainManager()
     
-    //배경화면
+    // 배경화면
     let roomImageView: UIImageView = {
         let imageView = UIImageView(frame: .zero)
         let myImage: UIImage = UIImage(named: "roomImage")!
@@ -23,7 +23,7 @@ class RoomViewController: UIViewController {
         return imageView
     }()
     
-    //메모 버튼 ImageView
+    // 메모 버튼 ImageView
     let memoImageView: UIImageView = {
         let imageView = UIImageView(frame: .zero)
         let myImage: UIImage = UIImage(named: "memo")!
@@ -32,7 +32,7 @@ class RoomViewController: UIViewController {
         return imageView
     }()
     
-    //앨범 버튼 ImageView
+    // 앨범 버튼 ImageView
     let albumImageView: UIImageView = {
         let imageView = UIImageView(frame: .zero)
         let myImage: UIImage = UIImage(named: "album")!
@@ -41,7 +41,7 @@ class RoomViewController: UIViewController {
         return imageView
     }()
     
-    //액자 버튼 ImageView
+    // 액자 버튼 ImageView
     let frameImageView: UIImageView = {
         let imageView = UIImageView(frame: .zero)
         let myImage: UIImage = UIImage(named: "frame")!
@@ -50,7 +50,7 @@ class RoomViewController: UIViewController {
         return imageView
     }()
     
-    //액자 사진 버튼 ImageView
+    // 액자 사진 버튼 ImageView
     let frameHasImageView: UIImageView = {
         let imageView = UIImageView(frame: .zero)
         imageView.contentMode = .scaleAspectFill
@@ -63,7 +63,7 @@ class RoomViewController: UIViewController {
         return imageView
     }()
     
-    //편지 버튼 ImageView
+    // 편지 버튼 ImageView
     var letterImageView: UIImageView = {
         let imageView = UIImageView(frame: .zero)
         let myImage: UIImage = UIImage(named: "letter")!
@@ -91,6 +91,7 @@ class RoomViewController: UIViewController {
         view.addSubview(letterImageView)
         view.addSubview(frameHasImageView)
         
+        // 처음에 기본 이미지 추가
         if CoreDataManager.shared.frameImage?.count == 0 {
             CoreDataManager.shared.saveFrameCoreData(image: UIImage(systemName:"person.fill")!.pngData()!)
             CoreDataManager.shared.readFrameCoreData()
@@ -98,37 +99,38 @@ class RoomViewController: UIViewController {
         
         navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage(systemName: "gearshape.fill"), style: .plain, target: self, action: #selector(settingViewTapped))
         navigationItem.rightBarButtonItem?.tintColor = UIColor(named: "iconColor")
+        
         setupLayout()
         imageInput()
         
 
-        //배경화면 크기 AspectFill로 맞춤
+        // 배경화면 크기 AspectFill로 맞춤
         roomImageView.layer.masksToBounds = true
         roomImageView.contentMode = .scaleAspectFill
 
-        //메모 사진 터치 가능하도록 설정
+        // 메모 사진 터치 가능하도록 설정
         memoImageView.isUserInteractionEnabled = true
         memoImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(memoViewTapped(_:))))
         
-        //앨범 사진 터치 가능하도록 설정
+        // 앨범 사진 터치 가능하도록 설정
         albumImageView.isUserInteractionEnabled = true
         albumImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(albumViewTapped(_:))))
         
-        //액자 사진 터치 가능하도록 설정
+        // 액자 사진 터치 가능하도록 설정
         frameImageView.isUserInteractionEnabled = true
         frameImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(frameViewTapped(_:))))
         frameHasImageView.isUserInteractionEnabled = true
         frameHasImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(frameViewTapped(_:))))
         
-        //편지 사진 터치 가능하도록 설정
+        // 편지 사진 터치 가능하도록 설정
         letterImageView.isUserInteractionEnabled = true
         letterImageView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(letterViewTapped(_:))))
         
-        //모달 닫히는 것 감지하여 토스트 수행
+        // 모달 닫히는 것 감지하여 토스트 수행
         NotificationCenter.default.addObserver(self, selector: #selector(rotate), name: .rotateBack, object: nil)
     }
     
-    //DoorViewController를 띄우고 한번이라도 실행되었다면 다음부턴 안띄움
+    // DoorViewController를 띄우고 한번이라도 실행되었다면 다음부턴 안띄움
     override func viewDidAppear(_ animated: Bool) {
         let doorViewController = DoorViewController()
         doorViewController.modalPresentationStyle = .overFullScreen
@@ -144,31 +146,31 @@ class RoomViewController: UIViewController {
             roomImageView.widthAnchor.constraint(equalToConstant: view.bounds.width),
             roomImageView.heightAnchor.constraint(equalToConstant: view.bounds.height),
             
-            //memoImageView layout
+            // memoImageView layout
             memoImageView.widthAnchor.constraint(equalToConstant: 124),
             memoImageView.heightAnchor.constraint(equalToConstant: 79),
             memoImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: -90),
             memoImageView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: 40),
             
-            //albumImageView layout
+            // albumImageView layout
             albumImageView.widthAnchor.constraint(equalToConstant: 73),
             albumImageView.heightAnchor.constraint(equalToConstant: 92),
             albumImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant:  -115),
             albumImageView.bottomAnchor.constraint(equalTo: memoImageView.topAnchor, constant: -120),
             
-            //frameImageView layout
+            // frameImageView layout
             frameImageView.widthAnchor.constraint(equalToConstant: 68),
             frameImageView.heightAnchor.constraint(equalToConstant: 100),
             frameImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: 20),
             frameImageView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             
-            //frameHasImageView layout
+            // frameHasImageView layout
             frameHasImageView.widthAnchor.constraint(equalToConstant: 53),
             frameHasImageView.heightAnchor.constraint(equalToConstant: 85),
             frameHasImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor, constant: 20),
             frameHasImageView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
             
-            //letterImageView layout
+            // letterImageView layout
             letterImageView.widthAnchor.constraint(equalToConstant: 77),
             letterImageView.heightAnchor.constraint(equalToConstant: 66),
             letterImageView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -45),
@@ -176,7 +178,7 @@ class RoomViewController: UIViewController {
         ])
     }
     
-    //CoreData를 읽어와서 이미지를 전달하는 함수
+    // CoreData를 읽어와서 이미지를 전달하는 함수
     func imageInput(){
         CoreDataManager.shared.readFrameCoreData()
         if let image = CoreDataManager.shared.frameImage?.last {
@@ -186,13 +188,13 @@ class RoomViewController: UIViewController {
         }
     }
 
-    //세팅 버튼 터치 함수
+    // 세팅 버튼 터치 함수
     @objc func settingViewTapped() {
         let settingVC = SettingViewController()
         self.navigationController?.pushViewController(settingVC, animated: true)
     }
 
-    //토스트 알림 함수
+    // 토스트 알림 함수
     @objc func rotate(_ sender: UITapGestureRecognizer) {
         func showToast(font: UIFont = UIFont.systemFont(ofSize: 16.0)) {
             let toastLabel = UILabel()
@@ -219,30 +221,28 @@ class RoomViewController: UIViewController {
         if letterCloseCheck {
             showToast()
             letterCloseCheck = false
-            // 테스트
-            print("dkssud")
         }
     }
     
-    //메모 버튼 터치 함수
+    // 메모 버튼 터치 함수
     @objc func memoViewTapped(_ sender: UITapGestureRecognizer) {
         let memoVC = MainMemoView()
         self.navigationController?.pushViewController(memoVC, animated: true)
     }
     
-    //앨범 버튼 터치 함수
+    // 앨범 버튼 터치 함수
     @objc func albumViewTapped(_ sender: UITapGestureRecognizer) {
         let albumVC = MainAlbumViewController()
         self.navigationController?.pushViewController(albumVC, animated: true)
     }
     
-    //액자 버튼 터치 함수
+    // 액자 버튼 터치 함수
     @objc func frameViewTapped(_ sender: UITapGestureRecognizer) {
         let frameVC = MainFrameViewController()
         self.navigationController?.pushViewController(frameVC, animated: true)
     }
     
-    //편지 버튼 터치 함수
+    // 편지 버튼 터치 함수
     @objc func letterViewTapped(_ sender: UITapGestureRecognizer) {
         let letterVC = MainLetterViewController()
         letterVC.modalPresentationStyle = UIModalPresentationStyle.automatic


### PR DESCRIPTION
## 세부 사항
- [FEAT] 액자 기본 이미지 추가
- [FIX] 액자 이미지 깨짐(찌그러짐) 수정
- [FIX] 앨범에서 일부 이미지 저장 시 강제로 회전하여 저장되던 부분 수정
- [DESIGN] 액자 이미지 선택 화면에서 취소 버튼 위치 살짝 조정
- [REFACTOR] 중복 사용되는 코드 함수 하나로 합쳐서 리팩토링

## 기타 질문 및 특이 사항
- 앨범 이미지 회전하는 부분 찾아보니까 이미지 자체에 있는 문제인 것 같았습니다. 그래서 아래 링크의 코드를 참조하여 UIImage에 extension으로 회전 수정하는 함수를 추가해 고쳤습니다.
- https://stackoverflow.com/questions/53949421/selecting-images-with-uiimagepickercontroller-auto-rotates-them
- Resolves #26 , Resolves #34 
 
## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge)
- [x]  필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [x]  코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [x]  제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [x]  본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
